### PR TITLE
deprecate notice with link to articles replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 fh-cordova-plugin-sms
 =====================
 
+> Note: **this plugin has ben deprecated since RHMAP 3.11 in favour of [cordova-sms-plugin](https://github.com/cordova-sms/cordova-sms-plugin)**. See this [support articlie](https://access.redhat.com/articles/2361891) for more details. 
+
 A cordova plugin for sending SMS in background. 
 
 Android only.


### PR DESCRIPTION
@jcesarmobile mind a quick review as we discussed the deprecation of this plugin since 3.11